### PR TITLE
Bug/header height

### DIFF
--- a/IGRPhotoTweaks/PhotoTweakView/IGRPhotoTweakView+IGRCropView.swift
+++ b/IGRPhotoTweaks/PhotoTweakView/IGRPhotoTweakView+IGRCropView.swift
@@ -53,7 +53,7 @@ extension IGRPhotoTweakView : IGRCropViewDelegate {
                                      y: CGFloat.zero,
                                      width: (newCropBounds.size.width),
                                      height: (newCropBounds.size.height))
-            cropView.center = CGPoint(x: self.frame.width.half, y: self.frame.height.half)
+            cropView.center = CGPoint(x: self.frame.width.half, y: self.centerY)
 
             // update scrollView
             self.updatePosition()

--- a/IGRPhotoTweaks/PhotoTweakView/IGRPhotoTweakView.swift
+++ b/IGRPhotoTweaks/PhotoTweakView/IGRPhotoTweakView.swift
@@ -182,7 +182,7 @@ public class IGRPhotoTweakView: UIView {
     fileprivate func maxBounds() -> CGRect {
         // scale the image
         self.maximumCanvasSize = CGSize(width: (kMaximumCanvasWidthRatio * self.frame.size.width),
-                                        height: (kMaximumCanvasHeightRatio * self.frame.size.height))
+                                        height: (kMaximumCanvasHeightRatio * self.frame.size.height - self.canvasHeaderHeigth()))
         
         let scaleX: CGFloat = self.image.size.width / self.maximumCanvasSize.width
         let scaleY: CGFloat = self.image.size.height / self.maximumCanvasSize.height

--- a/IGRPhotoTweaks/PhotoTweakView/IGRPhotoTweakView.swift
+++ b/IGRPhotoTweaks/PhotoTweakView/IGRPhotoTweakView.swift
@@ -44,7 +44,7 @@ public class IGRPhotoTweakView: UIView {
                                                              to: self)
             let point = CGPoint(x: (rect.origin.x + rect.size.width.half),
                                 y: (rect.origin.y + rect.size.height.half))
-            let zeroPoint = CGPoint(x: self.frame.width.half, y: self.frame.height.half)
+            let zeroPoint = CGPoint(x: self.frame.width.half, y: self.centerY)
             
             return CGPoint(x: (point.x - zeroPoint.x), y: (point.y - zeroPoint.y))
         }
@@ -82,7 +82,7 @@ public class IGRPhotoTweakView: UIView {
         self.originalSize = maxBounds.size
         
         let scrollView = IGRPhotoScrollView(frame: maxBounds)
-        scrollView.center = CGPoint(x: self.frame.width.half, y: self.frame.height.half)
+        scrollView.center = CGPoint(x: self.frame.width.half, y: self.centerY)
         scrollView.delegate = self
         scrollView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         self.addSubview(scrollView)
@@ -107,6 +107,10 @@ public class IGRPhotoTweakView: UIView {
 
     // constants
     fileprivate var maximumCanvasSize: CGSize!
+    var centerY: CGFloat {
+        return self.canvasHeaderHeigth() + (self.frame.size.height - self.canvasHeaderHeigth()) / 2
+    }
+
     fileprivate var originalPoint: CGPoint!
 
     // MARK: - Life Cicle
@@ -133,7 +137,7 @@ public class IGRPhotoTweakView: UIView {
         
         if !manualMove {
             self.originalSize = self.maxBounds().size
-            self.scrollView.center = CGPoint(x: (self.frame.width * 0.5), y: self.frame.height.half)
+            self.scrollView.center = CGPoint(x: (self.frame.width * 0.5), y: centerY)
             
             self.cropView.center = self.scrollView.center
             self.scrollView.checkContentOffset()
@@ -146,7 +150,7 @@ public class IGRPhotoTweakView: UIView {
             self.straighten = CGFloat.zero
             self.rotation = CGFloat.zero
             self.scrollView.transform = CGAffineTransform.identity
-            self.scrollView.center = CGPoint(x: self.frame.width.half, y: self.frame.height.half)
+            self.scrollView.center = CGPoint(x: self.frame.width.half, y: self.centerY)
             self.scrollView.bounds = CGRect(x: CGFloat.zero,
                                             y: CGFloat.zero,
                                             width: self.originalSize.width,
@@ -162,7 +166,7 @@ public class IGRPhotoTweakView: UIView {
     public func applyDeviceRotation() {
         self.resetView()
         
-        self.scrollView.center = CGPoint(x: self.frame.width.half, y: self.frame.height.half)
+        self.scrollView.center = CGPoint(x: self.frame.width.half, y: centerY)
         self.scrollView.bounds = CGRect(x: CGFloat.zero,
                                         y: CGFloat.zero,
                                         width: self.originalSize.width,


### PR DESCRIPTION
Internally the header height constant is used to offset the canvas from the top. We'll use it to account for iPhone X's top safe area inset. 

Add convenience variable to compute `centerY` based on frame height and header height constant