### PR TITLE
[Feature] Updated cropView bounds to fit maximumCanvasSize

### DIFF
--- a/Example/ExampleCropViewController.swift
+++ b/Example/ExampleCropViewController.swift
@@ -66,11 +66,7 @@ class ExampleCropViewController: IGRPhotoTweakViewController {
     override func willTransition(to newCollection: UITraitCollection, with coordinator: UIViewControllerTransitionCoordinator) {
         super.willTransition(to: newCollection, with: coordinator)
         
-        coordinator.animate(alongsideTransition: { (context) in
-            self.view.layoutIfNeeded()
-        }) { (context) in
-            //
-        }
+        coordinator.animate(alongsideTransition: { _ in self.photoView.applyDeviceRotation()})
     }
     
     // MARK: - Actions

--- a/IGRPhotoTweaks/Constants/IGRPhotoTweakConstants.swift
+++ b/IGRPhotoTweaks/Constants/IGRPhotoTweakConstants.swift
@@ -21,7 +21,7 @@ let kGridLinesCount: Int = 8
 let kCropViewHotArea: CGFloat           = 22.0
 
 let kMaximumCanvasWidthRatio: CGFloat   = 0.9
-let kMaximumCanvasHeightRatio: CGFloat  = 0.8
+let kMaximumCanvasHeightRatio: CGFloat  = 0.9
 let kCanvasHeaderHeigth: CGFloat        = 100.0
 
 let kCropViewLineWidth: CGFloat         = 2.0

--- a/IGRPhotoTweaks/PhotoTweakView/IGRPhotoTweakView+AspectRatio.swift
+++ b/IGRPhotoTweaks/PhotoTweakView/IGRPhotoTweakView+AspectRatio.swift
@@ -12,8 +12,8 @@ extension IGRPhotoTweakView {
     public func resetAspectRect() {
         self.cropView.frame = CGRect(x: CGFloat.zero,
                                      y: CGFloat.zero,
-                                     width: self.originalSize.width,
-                                     height: self.originalSize.height)
+                                     width: self.maximumCanvasSize.width,
+                                     height: self.maximumCanvasSize.height)
         self.cropView.center = self.scrollView.center
         self.cropView.resetAspectRect()
         
@@ -21,7 +21,7 @@ extension IGRPhotoTweakView {
     }
     
     public func setCropAspectRect(aspect: String) {
-        self.cropView.setCropAspectRect(aspect: aspect, maxSize:self.originalSize)
+        self.cropView.setCropAspectRect(aspect: aspect, maxSize:self.maximumCanvasSize)
         self.cropView.center = self.scrollView.center
         
         self.cropViewDidStopCrop(self.cropView)

--- a/IGRPhotoTweaks/PhotoTweakView/IGRPhotoTweakView+IGRCropView.swift
+++ b/IGRPhotoTweaks/PhotoTweakView/IGRPhotoTweakView+IGRCropView.swift
@@ -6,7 +6,7 @@
 //
 //
 
-import Foundation
+import UIKit
 
 extension IGRPhotoTweakView {
     

--- a/IGRPhotoTweaks/PhotoTweakView/IGRPhotoTweakView+IGRCropView.swift
+++ b/IGRPhotoTweaks/PhotoTweakView/IGRPhotoTweakView+IGRCropView.swift
@@ -29,8 +29,8 @@ extension IGRPhotoTweakView : IGRCropViewDelegate {
     }
     
     public func cropViewDidStopCrop(_ cropView: IGRCropView) {
-        let scaleX: CGFloat = self.originalSize.width / cropView.bounds.size.width
-        let scaleY: CGFloat = self.originalSize.height / cropView.bounds.size.height
+        let scaleX: CGFloat = self.maximumCanvasSize.width / cropView.bounds.size.width
+        let scaleY: CGFloat = self.maximumCanvasSize.height / cropView.bounds.size.height
         let scale: CGFloat = min(scaleX, scaleY)
 
         // calculate the new bounds of crop view

--- a/IGRPhotoTweaks/PhotoTweakView/IGRPhotoTweakView.swift
+++ b/IGRPhotoTweaks/PhotoTweakView/IGRPhotoTweakView.swift
@@ -109,11 +109,10 @@ public class IGRPhotoTweakView: UIView {
     internal var flipTransform =  CGAffineTransform.identity
 
     // constants
-    fileprivate var maximumCanvasSize: CGSize!
+    internal var maximumCanvasSize: CGSize!
     var centerY: CGFloat {
         return self.canvasHeaderHeigth() + (self.frame.size.height - self.canvasHeaderHeigth()) / 2
     }
-
     fileprivate var originalPoint: CGPoint!
 
     // MARK: - Life Cicle

--- a/IGRPhotoTweaks/PhotoTweakView/IGRPhotoTweakView.swift
+++ b/IGRPhotoTweaks/PhotoTweakView/IGRPhotoTweakView.swift
@@ -79,7 +79,6 @@ public class IGRPhotoTweakView: UIView {
     
     internal lazy var scrollView: IGRPhotoScrollView! = { [unowned self] by in
         let maxBounds = self.maxBounds()
-        self.originalSize = maxBounds.size
         
         let scrollView = IGRPhotoScrollView(frame: maxBounds)
         scrollView.center = CGPoint(x: self.frame.width.half, y: self.centerY)
@@ -91,7 +90,6 @@ public class IGRPhotoTweakView: UIView {
     }(())
     
     internal weak var image: UIImage!
-    internal var originalSize = CGSize.zero
 
     internal var manualMove   = false
 
@@ -138,7 +136,6 @@ public class IGRPhotoTweakView: UIView {
         super.layoutSubviews()
         
         if !manualMove {
-            self.originalSize = self.maxBounds().size
             self.scrollView.center = CGPoint(x: (self.frame.width * 0.5), y: centerY)
             
             self.cropView.center = self.scrollView.center
@@ -155,8 +152,8 @@ public class IGRPhotoTweakView: UIView {
             self.scrollView.center = CGPoint(x: self.frame.width.half, y: self.centerY)
             self.scrollView.bounds = CGRect(x: CGFloat.zero,
                                             y: CGFloat.zero,
-                                            width: self.originalSize.width,
-                                            height: self.originalSize.height)
+                                            width: self.maximumCanvasSize.width,
+                                            height: self.maximumCanvasSize.height)
             self.scrollView.minimumZoomScale = 1.0
             self.scrollView.setZoomScale(1.0, animated: false)
             
@@ -169,16 +166,13 @@ public class IGRPhotoTweakView: UIView {
         self.resetView()
         
         self.scrollView.center = CGPoint(x: self.frame.width.half, y: centerY)
-        self.scrollView.bounds = CGRect(x: CGFloat.zero,
-                                        y: CGFloat.zero,
-                                        width: self.originalSize.width,
-                                        height: self.originalSize.height)
+        self.scrollView.bounds = self.maxBounds()
         
-        self.cropView.frame = self.scrollView.frame
+        self.cropView.frame = self.scrollView.bounds
         self.cropView.center = self.scrollView.center
         
         // Update 'photoContent' frame and set the image.
-        self.scrollView.photoContentView.frame = .init(x: .zero, y: .zero, width: self.cropView.frame.width, height: self.cropView.frame.height)
+        self.scrollView.photoContentView.frame = self.cropView.bounds
         self.scrollView.photoContentView.image = self.image
         
         updatePosition()


### PR DESCRIPTION
## Description

Currently the cropView frame will fit the original image size

## Change

Change cropView frame to use preview size not image size

[[Card] Update cropView bounds](https://trello.com/c/ALvEzIr9/4520-photo-effect-editor-crop-area-boundary-should-not-follow-the-image-hight-width)