### PR TITLE
[BUG] Disable content inset adjustment

### DIFF
--- a/IGRPhotoTweaks/PhotoTweakView/IGRPhotoTweakView.swift
+++ b/IGRPhotoTweaks/PhotoTweakView/IGRPhotoTweakView.swift
@@ -82,6 +82,9 @@ public class IGRPhotoTweakView: UIView {
         
         let scrollView = IGRPhotoScrollView(frame: maxBounds)
         scrollView.center = CGPoint(x: self.frame.width.half, y: self.centerY)
+        if #available(iOS 11, *) {
+            scrollView.contentInsetAdjustmentBehavior = UIScrollView.ContentInsetAdjustmentBehavior.never;
+        }
         scrollView.delegate = self
         scrollView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         self.addSubview(scrollView)

--- a/IGRPhotoTweaks/PhotoTweakView/IGRPhotoTweakView.swift
+++ b/IGRPhotoTweaks/PhotoTweakView/IGRPhotoTweakView.swift
@@ -82,11 +82,13 @@ public class IGRPhotoTweakView: UIView {
         
         let scrollView = IGRPhotoScrollView(frame: maxBounds)
         scrollView.center = CGPoint(x: self.frame.width.half, y: self.centerY)
+        scrollView.delegate = self
+        scrollView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+
         if #available(iOS 11, *) {
             scrollView.contentInsetAdjustmentBehavior = UIScrollView.ContentInsetAdjustmentBehavior.never;
         }
-        scrollView.delegate = self
-        scrollView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        
         self.addSubview(scrollView)
         
         return scrollView


### PR DESCRIPTION
## Description

View controller automatically adjust inset for the scroll view, causing the content offset to be wrong when restoring a previous crop